### PR TITLE
Update h2cSmugglingCheck.py

### DIFF
--- a/extensions/BurpExtension/h2cSmugglingCheck.py
+++ b/extensions/BurpExtension/h2cSmugglingCheck.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from burp import IBurpExtender
 from burp import IScannerCheck
 from burp import IScanIssue


### PR DESCRIPTION
Fixed.
```
'/Users/rwiggins/Downloads/h2cSmugglingCheck.py', but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

	at org.python.core.Py.SyntaxError(Py.java:198)
	at org.python.core.ParserFacade.fixParseError(ParserFacade.java:105)
	at org.python.core.ParserFacade.parse(ParserFacade.java:190)
	at org.python.core.Py.compile_flags(Py.java:1956)
	at org.python.core.__builtin__.execfile_flags(__builtin__.java:527)
	at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:286)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at burp.dh0.<init>(Unknown Source)
	at burp.frl.a(Unknown Source)
	at burp.bmd.lambda$panelLoaded$0(Unknown Source)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)

```
