### PR TITLE
DeprecationWarning: ssl.wrap_socket() is deprecated, use SSLContext.w…

### DIFF
--- a/h2csmuggler.py
+++ b/h2csmuggler.py
@@ -46,7 +46,10 @@ def establish_tcp_connection(proxy_url):
 
     retSock = sock
     if proxy_url.scheme == "https":
-        retSock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        retSock = context.wrap_socket(sock, server_hostname=proxy_url.hostname)
 
     retSock.settimeout(MAX_TIMEOUT)
     retSock.connect(connect_args)


### PR DESCRIPTION
Fix the warning below.

./h2csmuggler-proxy.py:49: DeprecationWarning: ssl.wrap_socket() is deprecated, use SSLContext.wrap_socket()
  retSock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)

Ref. https://docs.python.org/3/library/ssl.html#:~:text=Deprecated%20since%20version%203.7%3A%20Since%20Python%203.2%20and%202.7.9%2C%20it%20is%20recommended%20to%20use%20the%20SSLContext.wrap_socket()%20instead%20of%20wrap_socket().