### PR TITLE
Update h2csmuggler.py

### DIFF
--- a/h2csmuggler.py
+++ b/h2csmuggler.py
@@ -46,7 +46,10 @@ def establish_tcp_connection(proxy_url):
 
     retSock = sock
     if proxy_url.scheme == "https":
-        retSock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLS)
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        retSock = context.wrap_socket(sock, server_hostname=proxy_url.hostname)
 
     retSock.settimeout(MAX_TIMEOUT)
     retSock.connect(connect_args)


### PR DESCRIPTION
从 Python 3.7 开始，ssl.wrap_socket 已被逐步废弃并最终移除，推荐使用 SSLContext 来代替 ssl.wrap_socket。

#### Card

#### Details
